### PR TITLE
Enabling deletion of JSS deployment

### DIFF
--- a/modules/data_warehouse/variables.tf
+++ b/modules/data_warehouse/variables.tf
@@ -50,13 +50,13 @@ variable "enable_apis" {
 variable "force_destroy" {
   type        = string
   description = "Whether or not to protect BigQuery resources from deletion when solution is modified or changed."
-  default     = false
+  default     = true
 }
 
 variable "deletion_protection" {
   type        = string
   description = "Whether or not to protect GCS resources from deletion when solution is modified or changed."
-  default     = true
+  default     = false
 }
 
 


### PR DESCRIPTION
**What?**
This pull request introduces modifications to enable the deletion of a deployed solution after editing the JSS code. 

**Why?**
Without these changes, developers/builders encounter limitations preventing them from deleting a deployment.

**How?**
`force_destroy` and `deletion_protection` flags protect GCS resources from deletion when solution is modified. So flipping these flags will enable the deletion.