### PR TITLE
Update deployment script to terminate on errors

### DIFF
--- a/modules/data_warehouse/deploy.sh
+++ b/modules/data_warehouse/deploy.sh
@@ -12,6 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -o pipefail  
+
+handle_error() {
+    local exit_code=$?
+    exit $exit_code
+}
+trap 'handle_error' ERR
 
 echo "Fetching Project ID"
 PROJECT_ID=$(gcloud config get project)


### PR DESCRIPTION
### Summary
This pull request addresses an issue where the script continued execution even after encountering errors during the execution of gcloud commands. 

The primary changes implemented to include `set -o pipefail` to ensure script termination upon pipeline failures and the addition of the `handle_error` function, designed to gracefully handle errors during script execution

### Testing
[See the terminal output before fixes](https://paste.googleplex.com/5997898261594112)
[See the terminal output after fixes](https://paste.googleplex.com/6005556221837312)